### PR TITLE
Handle column number discrepancy more gracefully

### DIFF
--- a/csvtomd.py
+++ b/csvtomd.py
@@ -10,6 +10,7 @@ More info: http://github.com/mplewis/csvtomd
 
 import argparse
 from csv import reader
+import sys
 
 
 def check_negative(value):
@@ -61,6 +62,8 @@ def md_table(table, *, padding=1, divider='|', header_div='-'):
     else:
         header_div_row = divider.join(header_divs)
     for row in table:
+        if len(row) != num_cols:
+            sys.exit('Not all rows have the same number of columns')
         for cell_num, cell in enumerate(row):
             # Pad each cell to the column size
             row[cell_num] = pad_to(cell, col_sizes[cell_num])


### PR DESCRIPTION
If not all rows have the same number of columns, exit with an
error message and status.  This is only a mild improvement
over the existing exception that happens.  Ideally, the code
should report the number of the first line that doesn't
have the same number of columns as the initial line.
