### PR TITLE
Added delimiter parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Doesn't require any external packages, so it should be platform-agnostic.
 Command: `csvtomd --help`
 
 ```
-usage: csvtomd.py [-h] [-n] [-p PADDING] csv_file [csv_file ...]
+usage: csvtomd.py [-h] [-n] [-p PADDING] [-d DELIMITER] csv_file [csv_file ...]
 
 Read one or more CSV files and output their contents in the form of Markdown
 tables.
@@ -101,6 +101,8 @@ optional arguments:
   -p PADDING, --padding PADDING
                         The number of spaces to add between table cells and
                         column dividers. Default is 2 spaces.
+  -d DELIMITER, --delimiter DELIMITER
+                        CSV delimiter, expected values: ',', ';'. Default is ,
 ```
 
 # Contributions

--- a/csvtomd/csvtomd.py
+++ b/csvtomd/csvtomd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-csvtomd v0.1.1
+csvtomd v0.1.2
 
 Convert your CSV files into Markdown tables.
 
@@ -100,6 +100,8 @@ def main():
     parser.add_argument('-p', '--padding', type=check_negative, default=2,
                         help="The number of spaces to add between table cells "
                              "and column dividers. Default is 2 spaces.")
+    parser.add_argument('-d', '--delimiter', default=',',
+                        help="CSV delimiter, expected values: ',', ';'. Default is %(default)s")
 
     args = parser.parse_args()
     first = True
@@ -111,7 +113,7 @@ def main():
             first = False
         # Read the CSV files
         with open(filename, 'rU') as f:
-            csv = reader(f)
+            csv = reader(f, delimiter=args.delimiter)
             table = [row for row in csv]
         # Print filename for each table if --no-filenames wasn't passed and more
         # than one CSV was provided

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst') as f:
 
 setup(
     name='csvtomd',
-    version='0.1.1',
+    version='0.1.2',
     description='Convert your CSV files into Markdown tables.',
     long_description=long_description,
     url='https://github.com/mplewis/csvtomd',


### PR DESCRIPTION
I add delimiter parameter because many csv files uses another delimiter. Most often ',' or ';'. And of course there is `tsv` format (delimeter `\t`). In unix shell you can handover escape char like `\t`:

``` bash
./csvtomd.py -d $'\t' tab.tsv
```
