### PR TITLE
Update csvtomd.py

### DIFF
--- a/csvtomd/csvtomd.py
+++ b/csvtomd/csvtomd.py
@@ -107,7 +107,7 @@ def md_table(table, *, padding=DEFAULT_PADDING, divider='|', header_div='-'):
 
 
 def csv_to_table(file, delimiter):
-    return list(csv.reader(file, delimiter=delimiter))
+    return list(csv.reader(file, delimiter=delimiter, skipinitialspace=True))
 
 
 def main():


### PR DESCRIPTION
hello, this is row 1, foo1
hello, this is row 2, foo2
goodbye, "this, is row 3", foo3

so that it produces

['hello', 'this is row 1', 'foo1'] 3
['hello', 'this is row 2', 'foo2'] 3
['goodbye', 'this, is row 3', 'foo3'] 3

https://stackoverflow.com/questions/6879596/why-is-the-python-csv-reader-ignoring-double-quoted-fields