### PR TITLE
Added support for \t escaped tab delimiter.

### DIFF
--- a/csvtomd/csvtomd.py
+++ b/csvtomd/csvtomd.py
@@ -11,6 +11,7 @@ More info: http://github.com/mplewis/csvtomd
 import argparse
 import csv
 import sys
+import codecs
 
 
 DEFAULT_PADDING = 2
@@ -107,7 +108,7 @@ def md_table(table, *, padding=DEFAULT_PADDING, divider='|', header_div='-'):
 
 
 def csv_to_table(file, delimiter):
-    return list(csv.reader(file, delimiter=delimiter))
+    return list(csv.reader(file, delimiter=codecs.decode(delimiter, 'unicode_escape')))
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-with open('README.rst') as f:
+with open('README.md') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
This allows the delimiter to be specified as any of the standard Python escape characters:

eg:

`csvtomd -d "\t" mydata.tsv`

I also fixed the filename for the README referenced in `setup.py`.