### PR TITLE
Removing redundant asterisk in md_table signature

### DIFF
--- a/csvtomd/csvtomd.py
+++ b/csvtomd/csvtomd.py
@@ -80,7 +80,7 @@ def add_dividers(row, divider, padding):
     return div.join(row)
 
 
-def md_table(table, *, padding=DEFAULT_PADDING, divider='|', header_div='-'):
+def md_table(table, padding=DEFAULT_PADDING, divider='|', header_div='-'):
     """
     Convert a 2D array of items into a Markdown table.
 


### PR DESCRIPTION
Running with Python 3.5.3 and getting:

```
$ python csvtomd.py 
  File "csvtomd.py", line 38
    def md_table(table, *, padding=1, divider='|', header_div='-'):
                         ^
SyntaxError: invalid syntax
```